### PR TITLE
[#1] Entity 세팅 및 매핑

### DIFF
--- a/src/main/java/likelion/dotoread/DotoreadApplication.java
+++ b/src/main/java/likelion/dotoread/DotoreadApplication.java
@@ -2,8 +2,10 @@ package likelion.dotoread;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class DotoreadApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/likelion/dotoread/domain/AcornAdd.java
+++ b/src/main/java/likelion/dotoread/domain/AcornAdd.java
@@ -3,8 +3,13 @@ package likelion.dotoread.domain;
 import jakarta.persistence.*;
 import likelion.dotoread.domain.common.BaseEntity;
 import likelion.dotoread.domain.mapping.UserMission;
+import lombok.*;
 
 @Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class AcornAdd extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/likelion/dotoread/domain/AcornAdd.java
+++ b/src/main/java/likelion/dotoread/domain/AcornAdd.java
@@ -1,0 +1,16 @@
+package likelion.dotoread.domain;
+
+import jakarta.persistence.*;
+import likelion.dotoread.domain.common.BaseEntity;
+import likelion.dotoread.domain.mapping.UserMission;
+
+@Entity
+public class AcornAdd extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Integer addAcorn;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="user_mission_id")
+    private UserMission userMission;
+}

--- a/src/main/java/likelion/dotoread/domain/AcornUse.java
+++ b/src/main/java/likelion/dotoread/domain/AcornUse.java
@@ -2,10 +2,15 @@ package likelion.dotoread.domain;
 
 import jakarta.persistence.*;
 import likelion.dotoread.domain.common.BaseEntity;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class AcornUse extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/likelion/dotoread/domain/AcornUse.java
+++ b/src/main/java/likelion/dotoread/domain/AcornUse.java
@@ -1,0 +1,21 @@
+package likelion.dotoread.domain;
+
+import jakarta.persistence.*;
+import likelion.dotoread.domain.common.BaseEntity;
+
+import java.time.LocalDateTime;
+
+@Entity
+public class AcornUse extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Integer useAcorn;
+    LocalDateTime usedAt;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+}

--- a/src/main/java/likelion/dotoread/domain/Bookmark.java
+++ b/src/main/java/likelion/dotoread/domain/Bookmark.java
@@ -1,0 +1,29 @@
+package likelion.dotoread.domain;
+
+import jakarta.persistence.*;
+import likelion.dotoread.domain.common.BaseEntity;
+import likelion.dotoread.domain.enums.Rating;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Entity
+public class Bookmark extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String url;
+    private String img;
+    private String memo;
+    @Builder.Default
+    private Integer visitCount = 0;
+    @Enumerated(EnumType.STRING)
+    private Rating rating;
+    private LocalDateTime visitedAt;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "folder_id")
+    private Folder folder;
+}

--- a/src/main/java/likelion/dotoread/domain/Bookmark.java
+++ b/src/main/java/likelion/dotoread/domain/Bookmark.java
@@ -3,11 +3,15 @@ package likelion.dotoread.domain;
 import jakarta.persistence.*;
 import likelion.dotoread.domain.common.BaseEntity;
 import likelion.dotoread.domain.enums.Rating;
-import lombok.Builder;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Bookmark extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/likelion/dotoread/domain/Folder.java
+++ b/src/main/java/likelion/dotoread/domain/Folder.java
@@ -2,11 +2,16 @@ package likelion.dotoread.domain;
 
 import jakarta.persistence.*;
 import likelion.dotoread.domain.common.BaseEntity;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Folder extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/likelion/dotoread/domain/Folder.java
+++ b/src/main/java/likelion/dotoread/domain/Folder.java
@@ -1,0 +1,17 @@
+package likelion.dotoread.domain;
+
+import jakarta.persistence.*;
+import likelion.dotoread.domain.common.BaseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class Folder extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    @OneToMany(mappedBy = "folder", cascade = CascadeType.ALL)
+    private List<Bookmark> bookmarkList = new ArrayList<>();
+}

--- a/src/main/java/likelion/dotoread/domain/Mission.java
+++ b/src/main/java/likelion/dotoread/domain/Mission.java
@@ -1,0 +1,20 @@
+package likelion.dotoread.domain;
+
+import jakarta.persistence.*;
+import likelion.dotoread.domain.common.BaseEntity;
+import likelion.dotoread.domain.mapping.UserMission;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class Mission extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String content;
+    private Integer goal;
+    private Integer reward;
+    @OneToMany(mappedBy = "mission", cascade = CascadeType.ALL)
+    private List<UserMission> userMissionList = new ArrayList<>();
+}

--- a/src/main/java/likelion/dotoread/domain/Mission.java
+++ b/src/main/java/likelion/dotoread/domain/Mission.java
@@ -3,11 +3,16 @@ package likelion.dotoread.domain;
 import jakarta.persistence.*;
 import likelion.dotoread.domain.common.BaseEntity;
 import likelion.dotoread.domain.mapping.UserMission;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Mission extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/likelion/dotoread/domain/Store.java
+++ b/src/main/java/likelion/dotoread/domain/Store.java
@@ -1,0 +1,18 @@
+package likelion.dotoread.domain;
+
+import jakarta.persistence.*;
+import likelion.dotoread.domain.common.BaseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class Store extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String content;
+    private Integer price;
+    @OneToMany(mappedBy = "store", cascade = CascadeType.ALL)
+    private List<AcornUse> acornUseList = new ArrayList<>();
+}

--- a/src/main/java/likelion/dotoread/domain/Store.java
+++ b/src/main/java/likelion/dotoread/domain/Store.java
@@ -2,11 +2,16 @@ package likelion.dotoread.domain;
 
 import jakarta.persistence.*;
 import likelion.dotoread.domain.common.BaseEntity;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Store extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/likelion/dotoread/domain/User.java
+++ b/src/main/java/likelion/dotoread/domain/User.java
@@ -3,12 +3,16 @@ package likelion.dotoread.domain;
 import jakarta.persistence.*;
 import likelion.dotoread.domain.common.BaseEntity;
 import likelion.dotoread.domain.mapping.UserMission;
-import lombok.Builder;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/likelion/dotoread/domain/User.java
+++ b/src/main/java/likelion/dotoread/domain/User.java
@@ -1,0 +1,30 @@
+package likelion.dotoread.domain;
+
+import jakarta.persistence.*;
+import likelion.dotoread.domain.common.BaseEntity;
+import likelion.dotoread.domain.mapping.UserMission;
+import lombok.Builder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class User extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String nickname;
+    private String email;
+    @Builder.Default
+    private Integer storageCount = 5;
+    @Builder.Default
+    private Integer acornCount = 0;
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Bookmark> bookmarkList = new ArrayList<>();
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<AcornUse> acornUseList = new ArrayList<>();
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<UserMission> userMissionList = new ArrayList<>();
+
+}

--- a/src/main/java/likelion/dotoread/domain/common/BaseEntity.java
+++ b/src/main/java/likelion/dotoread/domain/common/BaseEntity.java
@@ -1,0 +1,22 @@
+package likelion.dotoread.domain.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/likelion/dotoread/domain/enums/Rating.java
+++ b/src/main/java/likelion/dotoread/domain/enums/Rating.java
@@ -1,0 +1,13 @@
+package likelion.dotoread.domain.enums;
+
+import lombok.Generated;
+
+public enum Rating {
+    LOW("나쁨"),
+    MIDDLE("보통"),
+    HIGH("좋음");
+    private final String viewName;
+    Rating(String viewName){this.viewName = viewName;}
+    @Generated
+    public String getViewName(){return this.viewName;}
+}

--- a/src/main/java/likelion/dotoread/domain/mapping/UserMission.java
+++ b/src/main/java/likelion/dotoread/domain/mapping/UserMission.java
@@ -1,0 +1,28 @@
+package likelion.dotoread.domain.mapping;
+
+import jakarta.persistence.*;
+import likelion.dotoread.domain.AcornAdd;
+import likelion.dotoread.domain.Mission;
+import likelion.dotoread.domain.User;
+import likelion.dotoread.domain.common.BaseEntity;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Entity
+public class UserMission extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private LocalDateTime completedAt;
+    @Builder.Default
+    private Integer current = 0; //현재진행횟수
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_id")
+    private Mission mission;
+    @OneToOne(mappedBy = "userMission", cascade = CascadeType.ALL)
+    private AcornAdd acornAdd;
+}

--- a/src/main/java/likelion/dotoread/domain/mapping/UserMission.java
+++ b/src/main/java/likelion/dotoread/domain/mapping/UserMission.java
@@ -5,11 +5,15 @@ import likelion.dotoread.domain.AcornAdd;
 import likelion.dotoread.domain.Mission;
 import likelion.dotoread.domain.User;
 import likelion.dotoread.domain.common.BaseEntity;
-import lombok.Builder;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class UserMission extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/likelion/dotoread/repository/AcornAddRepository.java
+++ b/src/main/java/likelion/dotoread/repository/AcornAddRepository.java
@@ -1,0 +1,7 @@
+package likelion.dotoread.repository;
+
+import likelion.dotoread.domain.AcornAdd;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AcornAddRepository extends JpaRepository<AcornAdd, Long> {
+}

--- a/src/main/java/likelion/dotoread/repository/AcornUseRepository.java
+++ b/src/main/java/likelion/dotoread/repository/AcornUseRepository.java
@@ -1,0 +1,7 @@
+package likelion.dotoread.repository;
+
+import likelion.dotoread.domain.AcornUse;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AcornUseRepository extends JpaRepository<AcornUse, Long> {
+}

--- a/src/main/java/likelion/dotoread/repository/BookmarkRepository.java
+++ b/src/main/java/likelion/dotoread/repository/BookmarkRepository.java
@@ -1,0 +1,7 @@
+package likelion.dotoread.repository;
+
+import likelion.dotoread.domain.Bookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+}

--- a/src/main/java/likelion/dotoread/repository/FolderRepository.java
+++ b/src/main/java/likelion/dotoread/repository/FolderRepository.java
@@ -1,0 +1,7 @@
+package likelion.dotoread.repository;
+
+import likelion.dotoread.domain.Folder;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FolderRepository extends JpaRepository<Folder, Long> {
+}

--- a/src/main/java/likelion/dotoread/repository/MissionRepository.java
+++ b/src/main/java/likelion/dotoread/repository/MissionRepository.java
@@ -1,0 +1,7 @@
+package likelion.dotoread.repository;
+
+import likelion.dotoread.domain.Mission;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MissionRepository extends JpaRepository<Mission, Long> {
+}

--- a/src/main/java/likelion/dotoread/repository/StoreRepository.java
+++ b/src/main/java/likelion/dotoread/repository/StoreRepository.java
@@ -1,0 +1,7 @@
+package likelion.dotoread.repository;
+
+import likelion.dotoread.domain.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+}

--- a/src/main/java/likelion/dotoread/repository/UserMissionRepository.java
+++ b/src/main/java/likelion/dotoread/repository/UserMissionRepository.java
@@ -1,0 +1,7 @@
+package likelion.dotoread.repository;
+
+import likelion.dotoread.domain.mapping.UserMission;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserMissionRepository extends JpaRepository<UserMission, Long> {
+}

--- a/src/main/java/likelion/dotoread/repository/UserRepository.java
+++ b/src/main/java/likelion/dotoread/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package likelion.dotoread.repository;
+
+import likelion.dotoread.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}


### PR DESCRIPTION
## 📌 연관 이슈
- #1

## 💻 작업 내용

> 작업 내용을 간단히 설명해주세요

- entity를 세팅하고 연관관계를 매핑했습니다. 
- 모든 entity는 BaseEntity를 상속받아 생성일과 수정일이 자동으로 저장됩니다.
- entity별 respository를 생성했습니다.

### 📸 스크린샷 (선택)

### 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 기타 내용이 있다면 작성해주세요

- AcornUse의 use, AcornAdd의 add 칼럼의 경우, use와 add가 reserved word이므로 칼럼명으로 사용하면 에러가 발생했습니다. 따라서 각각 use_acorn, add_acorn으로 변경했습니다. 
- Bookmark의 Rating enum을 생성했습니다. 일단 임의로 나쁨, 보통, 좋음의 3단계로 구성해뒀습니다.