### PR TITLE
[#3] API 응답 통일 및 에러 핸들러 세팅

### DIFF
--- a/src/main/java/likelion/dotoread/api/ApiResponse.java
+++ b/src/main/java/likelion/dotoread/api/ApiResponse.java
@@ -1,0 +1,34 @@
+package likelion.dotoread.api;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import likelion.dotoread.api.code.BaseCode;
+import likelion.dotoread.api.code.status.SuccessStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+    public static <T> ApiResponse<T> onSuccess(T result){
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
+    }
+
+    public static <T> ApiResponse<T> of(BaseCode code, T result){
+            return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
+    }
+
+    public static <T> ApiResponse<T> onFailure(String code, String message, T data){
+        return new ApiResponse<>(false, code, message, data);
+    }
+}

--- a/src/main/java/likelion/dotoread/api/code/BaseCode.java
+++ b/src/main/java/likelion/dotoread/api/code/BaseCode.java
@@ -1,0 +1,8 @@
+package likelion.dotoread.api.code;
+
+public interface BaseCode {
+
+    public ReasonDto getReason();
+
+    public ReasonDto getReasonHttpStatus();
+}

--- a/src/main/java/likelion/dotoread/api/code/BaseErrorCode.java
+++ b/src/main/java/likelion/dotoread/api/code/BaseErrorCode.java
@@ -1,0 +1,8 @@
+package likelion.dotoread.api.code;
+
+public interface BaseErrorCode {
+
+    public ErrorReasonDto getReason();
+
+    public ErrorReasonDto getReasonHttpStatus();
+}

--- a/src/main/java/likelion/dotoread/api/code/ErrorReasonDto.java
+++ b/src/main/java/likelion/dotoread/api/code/ErrorReasonDto.java
@@ -1,0 +1,18 @@
+package likelion.dotoread.api.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ErrorReasonDto {
+    private String code;
+    private String message;
+    private HttpStatus httpStatus;
+    private Boolean isSuccess;
+}
+

--- a/src/main/java/likelion/dotoread/api/code/ReasonDto.java
+++ b/src/main/java/likelion/dotoread/api/code/ReasonDto.java
@@ -1,0 +1,18 @@
+package likelion.dotoread.api.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReasonDto {
+    private String code;
+    private String message;
+    private Boolean isSuccess;
+    private HttpStatus httpStatus;
+}
+

--- a/src/main/java/likelion/dotoread/api/code/status/ErrorStatus.java
+++ b/src/main/java/likelion/dotoread/api/code/status/ErrorStatus.java
@@ -1,0 +1,44 @@
+package likelion.dotoread.api.code.status;
+
+import likelion.dotoread.api.code.BaseErrorCode;
+import likelion.dotoread.api.code.ErrorReasonDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러입니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    EXCEPTION_TEST(HttpStatus.BAD_REQUEST, "TEST4001", "에러 테스트"),
+
+    ;
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDto getReason() {
+        return ErrorReasonDto.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDto getReasonHttpStatus() {
+        return ErrorReasonDto.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/likelion/dotoread/api/code/status/SuccessStatus.java
+++ b/src/main/java/likelion/dotoread/api/code/status/SuccessStatus.java
@@ -1,0 +1,37 @@
+package likelion.dotoread.api.code.status;
+
+import likelion.dotoread.api.code.BaseCode;
+import likelion.dotoread.api.code.ReasonDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+    _OK(HttpStatus.OK, "2000", "Ok"),
+    _TEST_OK(HttpStatus.OK, "2001","TEST Ok"),
+
+    ;
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDto getReason() {
+        return ReasonDto.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ReasonDto getReasonHttpStatus() {
+        return ReasonDto.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/likelion/dotoread/api/exception/ExceptionAdvice.java
+++ b/src/main/java/likelion/dotoread/api/exception/ExceptionAdvice.java
@@ -1,0 +1,124 @@
+package likelion.dotoread.api.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import jakarta.validation.ConstraintViolationException;
+import likelion.dotoread.api.ApiResponse;
+import likelion.dotoread.api.code.ErrorReasonDto;
+import likelion.dotoread.api.code.status.ErrorStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(constraintViolation -> constraintViolation.getMessage())
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
+
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY,request);
+    }
+
+
+    @Override
+    //protected로 변경
+    //HttpStatusCode로 변경
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        e.getBindingResult().getFieldErrors().stream()
+                .forEach(fieldError -> {
+                    String fieldName = fieldError.getField();
+                    String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+                    errors.merge(fieldName, errorMessage, (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+                });
+
+        return handleExceptionInternalArgs(e,HttpHeaders.EMPTY,ErrorStatus.valueOf("_BAD_REQUEST"),request,errors);
+    }
+
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        e.printStackTrace();
+
+        return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(),request, e.getMessage());
+    }
+
+    @ExceptionHandler(value = GeneralException.class)
+    public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
+        ErrorReasonDto errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        return handleExceptionInternal(generalException,errorReasonHttpStatus,null,request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDto reason,
+                                                           HttpHeaders headers, HttpServletRequest request) {
+
+        ApiResponse<Object> body = ApiResponse.onFailure(reason.getCode(),reason.getMessage(),null);
+//        e.printStackTrace();
+
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                reason.getHttpStatus(),
+                webRequest
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
+                                                                HttpHeaders headers, HttpStatus status, WebRequest request, String errorPoint) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorPoint);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                status,
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers, ErrorStatus errorCommonStatus,
+                                                               WebRequest request, Map<String, String> errorArgs) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorArgs);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
+                                                                     HttpHeaders headers, WebRequest request) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+}

--- a/src/main/java/likelion/dotoread/api/exception/GeneralException.java
+++ b/src/main/java/likelion/dotoread/api/exception/GeneralException.java
@@ -1,0 +1,23 @@
+package likelion.dotoread.api.exception;
+
+import likelion.dotoread.api.code.BaseErrorCode;
+import likelion.dotoread.api.code.ErrorReasonDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+
+    private BaseErrorCode code;
+
+    public ErrorReasonDto getErrorReason() {
+
+        return this.code.getReason();
+    }
+
+    public ErrorReasonDto getErrorReasonHttpStatus(){
+        return this.code.getReasonHttpStatus();
+    }
+}
+


### PR DESCRIPTION
## 📌 연관 이슈
- #3

## 💻 작업 내용

> 작업 내용을 간단히 설명해주세요

- API 응답 포맷을 통일하고, 에러 핸들러를 세팅했습니다. 
```
{
	isSuccess : Boolean
	code : String
	message : String
	result : {json}
}
```
`isSuccess : 성공 여부`
`code: HTTP 상태 코드 및 세부 사항`
`message: code에 대한 추가적인 설명`
`result: 성공 시 응답 json, 실패 시 null`
```java
@RestController
@RequestMapping("/test")
@RequiredArgsConstructor
public class TestController {
    @GetMapping("/success")
    public ApiResponse<TestResponse.TestDto> testAPI(){
        return ApiResponse.of(SuccessStatus._TEST_OK, TestConverter.toTestDto());
    }

    @GetMapping("/exception")
    public ApiResponse<TestResponse.TestDto> exceptionAPI(){
        throw new TestHandler(ErrorStatus.EXCEPTION_TEST);
    }

}
``` 
위와 같은 TestController를 작성하여 swagger로 테스트한 결과는 다음과 같습니다.

**test/success**
<img width="1066" alt="image" src="https://github.com/user-attachments/assets/7031d67a-a643-497d-a8c9-a73af446a9be">

**test/exception**
<img width="1068" alt="image" src="https://github.com/user-attachments/assets/9123474e-5896-4a88-9b8f-dab14e0ce66d">

### 📸 스크린샷 (선택)

### 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 기타 내용이 있다면 작성해주세요

### SuccessStatus
성공 응답이라면 SuccessStatus에 다음과 같은 코드를 추가하고 사용하면 됩니다.
```java
//예시
BOOKMARK_GET_OK(HttpStatus.OK, "BOOKMARK2001", "북마크 목록을 정상적으로 조회했습니다."),
BOOKMARK_DELETE_OK(HttpStatus.OK, "BOOKMARK2002", "북마크가 정상적으로 삭제되었습니다."),
``` 
```java
ApiResponse.of(SuccessStatus.BOOKMARK_GET_OK, ..);
``` 
### ErrorStatus
예를 들어 Folder와 관련된 에러라면 ErrorStatus에 아래와 같은 코드를 추가하고
```java
//예시
FOLDER_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLDER4001", "폴더가 없습니다."),
FOLDER_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "FOLDER4002", "이미 존재하는 폴더명입니다."),
``` 
다음과 같은 handler를 생성 후 사용하면 됩니다!
```java
//예시
public class FolderHandler extends GeneralException {
    public TestHandler(BaseErrorCode errorCode){
        super(errorCode);
    }
}
``` 
```java
throw new FolderHandler(ErrorStatus.FOLDER_NOT_FOUND);
``` 