### PR TITLE
[#5] 구글 소셜 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,17 @@ dependencies {
 
 	//swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
+	//jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+	//security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	//oauth2
+	implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 }
 
 tasks.named('test') {

--- a/src/main/java/likelion/dotoread/api/code/status/ErrorStatus.java
+++ b/src/main/java/likelion/dotoread/api/code/status/ErrorStatus.java
@@ -16,7 +16,14 @@ public enum ErrorStatus implements BaseErrorCode {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
-    EXCEPTION_TEST(HttpStatus.BAD_REQUEST, "TEST4001", "에러 테스트"),
+    //OAUTH
+    _ACCESS_NOT_FOUND(HttpStatus.NOT_FOUND, "OAUTH4001", "Access Token이 없습니다."),
+    _REFRESH_NOT_FOUND(HttpStatus.NOT_FOUND, "OAUTH4002", "Refresh Token이 없습니다."),
+    _ACCESS_INVALID(HttpStatus.BAD_REQUEST, "OAUTH4003", "Access Token이 유효하지 않습니다."),
+    _REFRESH_INVALID(HttpStatus.BAD_REQUEST,"OAUTH4004", "Refresh Token이 유효하지 않습니다."),
+    _ACCESS_EXPIRED(HttpStatus.BAD_REQUEST,"OAUTH4005", "Access Token이 만료되었습니다"),
+    _REFRESH_EXPIRED(HttpStatus.BAD_REQUEST,"OAUTH4006", "Refresh Token이 만료되었습니다"),
+
 
     ;
     private final HttpStatus httpStatus;

--- a/src/main/java/likelion/dotoread/api/code/status/SuccessStatus.java
+++ b/src/main/java/likelion/dotoread/api/code/status/SuccessStatus.java
@@ -9,7 +9,12 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum SuccessStatus implements BaseCode {
     _OK(HttpStatus.OK, "2000", "Ok"),
-    _TEST_OK(HttpStatus.OK, "2001","TEST Ok"),
+
+    //OAUTH
+    _GOOGLE_LOGIN_OK(HttpStatus.OK, "OAUTH2001", "구글 소셜 로그인이 완료되었습니다."),
+    _REFRESH_OK(HttpStatus.OK, "OAUTH2002", "토큰 재발급이 완료되었습니다."),
+    _SIGN_UP_OK(HttpStatus.OK,"OAUTH2003", "회원가입이 완료되었습니다."),
+    _LOGOUT_OK(HttpStatus.OK,"OAUTH2004","로그아웃이 완료되었습니다."),
 
     ;
     private final HttpStatus httpStatus;

--- a/src/main/java/likelion/dotoread/api/exception/handler/UserHandler.java
+++ b/src/main/java/likelion/dotoread/api/exception/handler/UserHandler.java
@@ -1,0 +1,10 @@
+package likelion.dotoread.api.exception.handler;
+
+import likelion.dotoread.api.code.BaseErrorCode;
+import likelion.dotoread.api.exception.GeneralException;
+
+public class UserHandler extends GeneralException {
+    public UserHandler(BaseErrorCode errorCode){
+        super(errorCode);
+    }
+}

--- a/src/main/java/likelion/dotoread/auth/jwt/JWTUtil.java
+++ b/src/main/java/likelion/dotoread/auth/jwt/JWTUtil.java
@@ -1,0 +1,53 @@
+package likelion.dotoread.auth.jwt;
+
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JWTUtil {
+
+    private SecretKey secretKey;
+
+    public JWTUtil(@Value("${spring.jwt.secret}")String secret) {
+
+
+        secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    public String getUsername(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
+    }
+
+    public String getRole(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+    }
+
+    public Boolean isExpired(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    }
+
+    public String createJwt(String category, String username, String role, Long expiredMs) {
+
+        return Jwts.builder()
+                .claim("category", category)
+                .claim("username", username)
+                .claim("role", role)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(secretKey)
+                .compact();
+    }
+    public String getCategory(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("category", String.class);
+    }
+}

--- a/src/main/java/likelion/dotoread/auth/jwt/filter/CustomLogoutFilter.java
+++ b/src/main/java/likelion/dotoread/auth/jwt/filter/CustomLogoutFilter.java
@@ -1,0 +1,126 @@
+package likelion.dotoread.auth.jwt.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import likelion.dotoread.api.ApiResponse;
+import likelion.dotoread.api.code.status.ErrorStatus;
+import likelion.dotoread.api.code.status.SuccessStatus;
+import likelion.dotoread.auth.jwt.JWTUtil;
+import likelion.dotoread.repository.RefreshRepository;
+import likelion.dotoread.web.dto.UserDto.UserResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class CustomLogoutFilter extends GenericFilterBean {
+
+    private final JWTUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+
+        doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
+    }
+
+    private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+
+        //path and method verify
+        String requestUri = request.getRequestURI();
+        if (!requestUri.matches("^\\/logout$")) {
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+        String requestMethod = request.getMethod();
+        if (!requestMethod.equals("POST")) {
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        //get refresh token
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {  // 쿠키가 null인지 먼저 확인
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals("refresh")) {
+                    refresh = cookie.getValue();
+                    break;
+                }
+            }
+        }
+        //refresh null check
+        if (refresh == null) {
+            sendErrorResponse(response, ErrorStatus._REFRESH_NOT_FOUND);
+            return;
+        }
+
+        //expired check
+        try {
+            jwtUtil.isExpired(refresh);
+        } catch (ExpiredJwtException e) {
+
+            //response status code
+            sendErrorResponse(response, ErrorStatus._REFRESH_EXPIRED);
+            return;
+        }
+
+        // 토큰이 refresh인지 확인 (발급시 페이로드에 명시)
+        String category = jwtUtil.getCategory(refresh);
+        if (!category.equals("refresh")) {
+
+            //response status code
+            sendErrorResponse(response, ErrorStatus._REFRESH_NOT_FOUND);
+            return;
+        }
+
+        //DB에 저장되어 있는지 확인
+        Boolean isExist = refreshRepository.existsByRefresh(refresh);
+        if (!isExist) {
+
+            //response status code
+            sendErrorResponse(response, ErrorStatus._REFRESH_NOT_FOUND);
+            return;
+        }
+
+        //로그아웃 진행
+        //Refresh 토큰 DB에서 제거
+        refreshRepository.deleteByRefresh(refresh);
+
+        //Refresh 토큰 Cookie 값 0
+        Cookie cookie = new Cookie("refresh", null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+
+        response.addCookie(cookie);
+        response.setStatus(HttpServletResponse.SC_OK);
+
+        ApiResponse<UserResponseDTO.JWTResponseDTO> apiResponse = ApiResponse.of(SuccessStatus._LOGOUT_OK,null);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpStatus.OK.value());
+        objectMapper.writeValue(response.getWriter(), apiResponse);
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, ErrorStatus errorStatus) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(errorStatus.getHttpStatus().value());
+
+        ApiResponse<?> apiResponse = ApiResponse.onFailure(errorStatus.getCode(), errorStatus.getMessage(), null);
+        objectMapper.writeValue(response.getWriter(), apiResponse);
+    }
+}

--- a/src/main/java/likelion/dotoread/auth/jwt/filter/JWTFilter.java
+++ b/src/main/java/likelion/dotoread/auth/jwt/filter/JWTFilter.java
@@ -1,0 +1,93 @@
+package likelion.dotoread.auth.jwt.filter;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import likelion.dotoread.api.ApiResponse;
+import likelion.dotoread.api.code.status.ErrorStatus;
+import likelion.dotoread.auth.jwt.JWTUtil;
+import likelion.dotoread.auth.oauth2.CustomOAuth2User;
+import likelion.dotoread.domain.User;
+import likelion.dotoread.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JWTFilter extends OncePerRequestFilter {
+
+    private final JWTUtil jwtUtil;
+    private final UserRepository userRepository;
+    private final ObjectMapper objectMapper;
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        // 헤더에서 access키에 담긴 토큰을 꺼냄
+        String accessToken = request.getHeader("access");
+        if (request.getRequestURI().equals("/reissue")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+// 토큰이 없다면 다음 필터로 넘김
+        if (accessToken == null) {
+
+            filterChain.doFilter(request, response);
+
+            return;
+        }
+
+
+// 토큰 만료 여부 확인, 만료시 다음 필터로 넘기지 않음
+        try {
+            jwtUtil.isExpired(accessToken);
+        } catch (ExpiredJwtException e) {
+
+            sendErrorResponse(response, ErrorStatus._ACCESS_EXPIRED);
+            return;
+        }
+
+// 토큰이 access인지 확인 (발급시 페이로드에 명시)
+        String category = jwtUtil.getCategory(accessToken);
+
+        if (!category.equals("access")) {
+
+            sendErrorResponse(response, ErrorStatus._ACCESS_INVALID);
+            return;
+        }
+
+
+        //토큰에서 username과 role 획득
+         String username = jwtUtil.getUsername(accessToken);
+        //String role = jwtUtil.getRole(accessToken);
+        User user = userRepository.findByUsername(username);
+
+        //UserDetails에 회원 정보 객체 담기
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(user);
+
+        //스프링 시큐리티 인증 토큰 생성
+        Authentication authToken = new UsernamePasswordAuthenticationToken(customOAuth2User, null, customOAuth2User.getAuthorities());
+        //세션에 사용자 등록
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        filterChain.doFilter(request, response);
+    }
+    private void sendErrorResponse(HttpServletResponse response, ErrorStatus errorStatus) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(errorStatus.getHttpStatus().value());
+
+        ApiResponse<?> apiResponse = ApiResponse.onFailure(errorStatus.getCode(), errorStatus.getMessage(), null);
+        objectMapper.writeValue(response.getWriter(), apiResponse);
+    }
+}

--- a/src/main/java/likelion/dotoread/auth/oauth2/CustomOAuth2User.java
+++ b/src/main/java/likelion/dotoread/auth/oauth2/CustomOAuth2User.java
@@ -1,0 +1,50 @@
+package likelion.dotoread.auth.oauth2;
+
+import likelion.dotoread.domain.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+public class CustomOAuth2User implements OAuth2User {
+    private final User user;
+    public CustomOAuth2User(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+
+        collection.add(new GrantedAuthority() {
+
+            @Override
+            public String getAuthority() {
+
+                return user.getRole();
+            }
+        });
+
+        return collection;
+    }
+
+    @Override
+    public String getName() {
+
+        return user.getName();
+    }
+
+    public String getUsername() {
+
+        return user.getUsername();
+    }
+}

--- a/src/main/java/likelion/dotoread/auth/oauth2/handler/CustomSuccessHandler.java
+++ b/src/main/java/likelion/dotoread/auth/oauth2/handler/CustomSuccessHandler.java
@@ -1,0 +1,114 @@
+package likelion.dotoread.auth.oauth2.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import likelion.dotoread.api.ApiResponse;
+import likelion.dotoread.api.code.status.SuccessStatus;
+import likelion.dotoread.auth.jwt.JWTUtil;
+import likelion.dotoread.auth.oauth2.CustomOAuth2User;
+import likelion.dotoread.converter.UserConverter;
+import likelion.dotoread.domain.RefreshToken;
+import likelion.dotoread.domain.User;
+import likelion.dotoread.repository.RefreshRepository;
+import likelion.dotoread.repository.UserRepository;
+import likelion.dotoread.service.UserService;
+import likelion.dotoread.web.dto.UserDto.UserResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Iterator;
+
+@Component
+@RequiredArgsConstructor
+public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JWTUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+    private final UserRepository userRepository;
+    private final ObjectMapper objectMapper;
+    private final UserService userService;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+
+        //OAuth2User
+        CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
+
+        String username = customUserDetails.getUsername();
+
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+        String role = auth.getAuthority();
+
+
+        // 액세스 토큰 생성 (1시간 유효)
+        String access = jwtUtil.createJwt("access", username, role, 3600000L);
+        // 리프레시 토큰 생성 (14일 유효)
+        String refresh = jwtUtil.createJwt("refresh", username, role, 1209600000L);
+        // 액세스 토큰은 헤더에 설정
+        response.setHeader("access", access);
+
+        User user = userRepository.findByUsername(username);
+        user.setAccessToken(access);
+        userRepository.save(user);
+
+        //Refresh 토큰 저장
+        if(refreshRepository.existsByUsername(username)) {
+            refreshRepository.deleteByUsername(username);
+        }
+        addRefreshEntity(username, refresh, 86400000L);
+
+        // 리프레시 토큰은 쿠키에 설정
+        response.addCookie(createCookie("refresh", refresh));
+
+        //회원가입인지, 로그인인지 구분
+        boolean isNew = userService.isNew(user);
+        String refreshToken = userService.findRefreshTokenByUser(user);
+        UserResponseDTO.JWTResponseDTO jwtResponseDTO = UserConverter.toJwtResponseDTO(user, refreshToken, isNew);
+
+        //로그인 응답
+        ApiResponse<UserResponseDTO.JWTResponseDTO> apiResponse = ApiResponse.of(SuccessStatus._GOOGLE_LOGIN_OK, jwtResponseDTO);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpStatus.OK.value());
+        objectMapper.writeValue(response.getWriter(), apiResponse);
+
+        // 리다이렉트
+//        response.sendRedirect("http://localhost:8080");
+
+    }
+
+    private Cookie createCookie(String key, String value) {
+
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(60*60*60);
+        //cookie.setSecure(true);
+        //cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+    private void addRefreshEntity(String username, String refresh, Long expiredMs) {
+
+        Date date = new Date(System.currentTimeMillis() + expiredMs);
+
+        RefreshToken refreshEntity = new RefreshToken();
+        refreshEntity.setUsername(username);
+        refreshEntity.setRefresh(refresh);
+        refreshEntity.setExpiration(date.toString());
+
+        refreshRepository.save(refreshEntity);
+    }
+}

--- a/src/main/java/likelion/dotoread/auth/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/likelion/dotoread/auth/oauth2/service/CustomOAuth2UserService.java
@@ -1,0 +1,59 @@
+package likelion.dotoread.auth.oauth2.service;
+
+import likelion.dotoread.auth.oauth2.CustomOAuth2User;
+import likelion.dotoread.domain.User;
+import likelion.dotoread.repository.UserRepository;
+import likelion.dotoread.web.dto.UserDto.GoogleResponse;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    public CustomOAuth2UserService(UserRepository userRepository) {
+
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        System.out.println(oAuth2User);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        GoogleResponse googleResponse = null;
+        if (registrationId.equals("google")) {
+
+            googleResponse = new GoogleResponse(oAuth2User.getAttributes());
+        }
+        else {
+
+            return null;
+        }
+        String username = googleResponse.getProvider()+" "+googleResponse.getProviderId();
+        User existData = userRepository.findByUsername(username);
+        User user = userRepository.findByUsername(username);
+
+        if (user == null) {
+            user = User.builder()
+                    .name(googleResponse.getName())
+                    .username(username)
+                    .email(googleResponse.getEmail())
+                    .role("ROLE_USER")
+                    .build();
+            userRepository.save(user);
+        } else {
+            user.setEmail(googleResponse.getEmail());
+            user.setName(googleResponse.getName());
+            userRepository.save(user);
+        }
+
+        return new CustomOAuth2User(user);
+    }
+}

--- a/src/main/java/likelion/dotoread/config/CorsMvcConfig.java
+++ b/src/main/java/likelion/dotoread/config/CorsMvcConfig.java
@@ -1,0 +1,24 @@
+package likelion.dotoread.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry corsRegistry) {
+
+        corsRegistry.addMapping("/**")
+                .exposedHeaders("Set-Cookie")
+                .allowedOrigins("http://localhost:3000","http://localhost:8080");
+//        corsRegistry.addMapping("/**")
+//                .allowedOrigins("http://localhost:3000", "http://localhost:8080", "http://localhost:8081")
+//                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+//                .allowedHeaders("Authorization", "Content-Type", "X-Requested-With", "accept", "Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers")
+//                .exposedHeaders("Access-Control-Allow-Origin", "Access-Control-Allow-Credentials", "Authorization", "Set-Cookie")
+//                .allowCredentials(true)
+//                .maxAge(3600);
+    }
+}

--- a/src/main/java/likelion/dotoread/config/SecurityConfig.java
+++ b/src/main/java/likelion/dotoread/config/SecurityConfig.java
@@ -1,0 +1,104 @@
+package likelion.dotoread.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import likelion.dotoread.auth.jwt.JWTUtil;
+import likelion.dotoread.auth.jwt.filter.CustomLogoutFilter;
+import likelion.dotoread.auth.jwt.filter.JWTFilter;
+import likelion.dotoread.auth.oauth2.handler.CustomSuccessHandler;
+import likelion.dotoread.auth.oauth2.service.CustomOAuth2UserService;
+import likelion.dotoread.repository.RefreshRepository;
+import likelion.dotoread.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final CustomSuccessHandler customSuccessHandler;
+    private final JWTUtil jwtUtil;
+    private final UserRepository userRepository;
+    //AuthenticationManager가 인자로 받을 AuthenticationConfiguraion 객체 생성자 주입
+    private final RefreshRepository refreshRepository;
+    private final ObjectMapper objectMapper;
+    //AuthenticationManager Bean 등록
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http
+                .cors(corsCustomizer -> corsCustomizer.configurationSource(new CorsConfigurationSource() {
+
+                    @Override
+                    public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
+
+                        CorsConfiguration configuration = new CorsConfiguration();
+
+                        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "http://localhost:8080", "http://localhost:8081"));
+                        configuration.setAllowedMethods(Collections.singletonList("*"));
+                        configuration.setAllowCredentials(true);
+                        configuration.setAllowedHeaders(Collections.singletonList("*"));
+                        configuration.setMaxAge(3600L);
+
+                        configuration.setExposedHeaders(Collections.singletonList("Set-Cookie"));
+                        configuration.setExposedHeaders(Collections.singletonList("Authorization"));
+
+
+                        return configuration;
+                    }
+                }));
+        //csrf disable
+        http
+                .csrf((auth) -> auth.disable());
+
+        //From 로그인 방식 disable
+        http
+                .formLogin((auth) -> auth.disable());
+
+        //HTTP Basic 인증 방식 disable
+        http
+                .httpBasic((auth) -> auth.disable());
+        //JWTFilter 추가
+//        http
+//                .addFilterBefore(new JWTFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+        http
+                .addFilterBefore(new CustomLogoutFilter(jwtUtil, refreshRepository, objectMapper), LogoutFilter.class);
+        //JWTFilter 추가
+        http
+                .addFilterAfter(new JWTFilter(jwtUtil, userRepository, objectMapper), OAuth2LoginAuthenticationFilter.class);
+        //oauth2
+        http
+                .oauth2Login((oauth2) -> oauth2
+                        .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
+                                .userService(customOAuth2UserService))
+                        .successHandler(customSuccessHandler)
+                );
+
+        //경로별 인가 작업
+        http
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/","/reissue").permitAll()
+                        .requestMatchers("/swagger-ui/**","/error","/swagger-resources/**","/v3/api-docs/**","/health").permitAll()
+                        .anyRequest().authenticated());
+
+        //세션 설정 : STATELESS
+        http
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        return http.build();
+    }
+}

--- a/src/main/java/likelion/dotoread/config/swagger/SwaggerConfig.java
+++ b/src/main/java/likelion/dotoread/config/swagger/SwaggerConfig.java
@@ -5,22 +5,33 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
-import io.swagger.v3.oas.models.security.SecurityScheme.Type;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
-    public SwaggerConfig() {
-    }
 
     @Bean
-    public OpenAPI stewAPI() {
-        Info info = (new Info()).title("DOTOREAD API").description("DOTOREAD API 명세서").version("1.0.0");
-        String jwtSchemeName = "JWT TOKEN";
-        SecurityRequirement securityRequirement = (new SecurityRequirement()).addList(jwtSchemeName);
-        Components components = (new Components()).addSecuritySchemes(jwtSchemeName, (new SecurityScheme()).name(jwtSchemeName).type(Type.HTTP).scheme("bearer").bearerFormat("JWT"));
-        return (new OpenAPI()).addServersItem((new Server()).url("/")).info(info).addSecurityItem(securityRequirement).components(components);
+    public OpenAPI dotoreadAPI() {
+        Info info = new Info()
+                .title("DOTOREAD API")
+                .description("DOTOREAD API 명세서")
+                .version("1.0.0");
+
+        String securitySchemeName = "access";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(securitySchemeName);
+
+        Components components = new Components()
+                .addSecuritySchemes(securitySchemeName, new SecurityScheme()
+                        .name(securitySchemeName)
+                        .type(SecurityScheme.Type.APIKEY)
+                        .in(SecurityScheme.In.HEADER));
+
+        return new OpenAPI()
+                .addServersItem(new Server().url("/"))
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .components(components);
     }
 }

--- a/src/main/java/likelion/dotoread/converter/UserConverter.java
+++ b/src/main/java/likelion/dotoread/converter/UserConverter.java
@@ -1,0 +1,14 @@
+package likelion.dotoread.converter;
+
+import likelion.dotoread.domain.User;
+import likelion.dotoread.web.dto.UserDto.UserResponseDTO;
+
+public class UserConverter {
+    public static UserResponseDTO.JWTResponseDTO toJwtResponseDTO(User user, String refreshToken, Boolean isNew) {
+        return UserResponseDTO.JWTResponseDTO.builder()
+                .refreshToken(refreshToken)
+                .accessToken(user.getAccessToken())
+                .isNew(isNew)
+                .build();
+    }
+}

--- a/src/main/java/likelion/dotoread/domain/Bookmark.java
+++ b/src/main/java/likelion/dotoread/domain/Bookmark.java
@@ -19,11 +19,11 @@ public class Bookmark extends BaseEntity {
     private String url;
     private String img;
     private String memo;
-    @Builder.Default
-    private Integer visitCount = 0;
     @Enumerated(EnumType.STRING)
     private Rating rating;
     private LocalDateTime visitedAt;
+    @Builder.Default
+    private Boolean isVisited = false;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;

--- a/src/main/java/likelion/dotoread/domain/RefreshToken.java
+++ b/src/main/java/likelion/dotoread/domain/RefreshToken.java
@@ -1,0 +1,20 @@
+package likelion.dotoread.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String username;
+    private String refresh;
+    private String expiration;
+}

--- a/src/main/java/likelion/dotoread/domain/User.java
+++ b/src/main/java/likelion/dotoread/domain/User.java
@@ -20,6 +20,9 @@ public class User extends BaseEntity {
     private String name;
     private String nickname;
     private String email;
+    private String accessToken;
+    private String username;
+    private String role;
     @Builder.Default
     private Integer storageCount = 5;
     @Builder.Default
@@ -30,5 +33,19 @@ public class User extends BaseEntity {
     private List<AcornUse> acornUseList = new ArrayList<>();
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<UserMission> userMissionList = new ArrayList<>();
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+    public void setEmail(String email) {
+        this.email = email;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setNickname(String nickname) {
+
+        this.nickname = nickname;
+    }
 
 }

--- a/src/main/java/likelion/dotoread/repository/RefreshRepository.java
+++ b/src/main/java/likelion/dotoread/repository/RefreshRepository.java
@@ -1,0 +1,18 @@
+package likelion.dotoread.repository;
+
+import likelion.dotoread.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface RefreshRepository extends JpaRepository<RefreshToken, Long> {
+
+    Boolean existsByRefresh(String refresh);
+    Boolean existsByUsername(String username);
+
+    @Transactional
+    void deleteByRefresh(String refresh);
+    @Transactional
+    void deleteByUsername(String username);
+
+    RefreshToken findByUsername(String username);
+}

--- a/src/main/java/likelion/dotoread/repository/UserRepository.java
+++ b/src/main/java/likelion/dotoread/repository/UserRepository.java
@@ -4,4 +4,5 @@ import likelion.dotoread.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    User findByUsername(String username);
 }

--- a/src/main/java/likelion/dotoread/service/UserService.java
+++ b/src/main/java/likelion/dotoread/service/UserService.java
@@ -1,0 +1,86 @@
+package likelion.dotoread.service;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import likelion.dotoread.api.code.status.ErrorStatus;
+import likelion.dotoread.api.exception.handler.UserHandler;
+import likelion.dotoread.auth.jwt.JWTUtil;
+import likelion.dotoread.domain.RefreshToken;
+import likelion.dotoread.domain.User;
+import likelion.dotoread.repository.RefreshRepository;
+import likelion.dotoread.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+    private final RefreshRepository refreshRepository;
+    private final JWTUtil jwtUtil;
+    public User findUserByHttpServletRequest(HttpServletRequest request) {
+        String accessToken = request.getHeader("access");
+        if (accessToken == null || accessToken.isEmpty()) {
+            throw new UserHandler(ErrorStatus._ACCESS_NOT_FOUND);
+        }
+        String username = jwtUtil.getUsername(accessToken);
+        return userRepository.findByUsername(username);
+    }
+    public boolean isNew(User user) {
+        if(user.getNickname() == null || user.getNickname().isEmpty()) {
+            return true;
+        }
+        else return false;
+    }
+
+    public String findRefreshTokenByUser(User user) {
+        RefreshToken refreshToken = refreshRepository.findByUsername(user.getUsername());
+        return refreshToken.getRefresh();
+    }
+    public void signUp(User user, String nickname) {
+        user.setNickname(nickname);
+        userRepository.save(user);
+    }
+    public String getRefresh(HttpServletRequest request, HttpServletResponse response, String refresh) {
+        //get refresh token
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("refresh".equals(cookie.getName())) {
+                    refresh = cookie.getValue();
+                    break;
+                }
+            }
+        }
+        if (refresh == null) {
+
+            //response status code
+            throw new UserHandler(ErrorStatus._REFRESH_NOT_FOUND);
+        }
+        //expired check
+        try {
+            jwtUtil.isExpired(refresh);
+        } catch (ExpiredJwtException e) {
+            //response status code
+            throw new UserHandler(ErrorStatus._REFRESH_EXPIRED);
+        }
+        // 토큰이 refresh인지 확인 (발급시 페이로드에 명시)
+        String category = jwtUtil.getCategory(refresh);
+
+        if (!category.equals("refresh")) {
+
+            //response status code
+            throw new UserHandler(ErrorStatus._REFRESH_INVALID);
+        }
+        //DB에 저장되어 있는지 확인
+        Boolean isExist = refreshRepository.existsByRefresh(refresh);
+        if (!isExist) {
+
+            //response body
+            throw new UserHandler(ErrorStatus._REFRESH_INVALID);
+        }
+        return refresh;
+    }
+}

--- a/src/main/java/likelion/dotoread/web/controller/UserController.java
+++ b/src/main/java/likelion/dotoread/web/controller/UserController.java
@@ -1,0 +1,79 @@
+package likelion.dotoread.web.controller;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import likelion.dotoread.api.ApiResponse;
+import likelion.dotoread.api.code.status.SuccessStatus;
+import likelion.dotoread.auth.jwt.JWTUtil;
+import likelion.dotoread.converter.UserConverter;
+import likelion.dotoread.domain.RefreshToken;
+import likelion.dotoread.domain.User;
+import likelion.dotoread.repository.RefreshRepository;
+import likelion.dotoread.repository.UserRepository;
+import likelion.dotoread.service.UserService;
+import likelion.dotoread.web.dto.UserDto.UserRequestDTO;
+import likelion.dotoread.web.dto.UserDto.UserResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Date;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+    private final JWTUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+    private final UserRepository userRepository;
+    @PostMapping("/sign-up")
+    public ApiResponse signUp(HttpServletRequest http, @RequestBody UserRequestDTO.SignUpDTO request) {
+        User user = userService.findUserByHttpServletRequest(http);
+        userService.signUp(user, request.getNickname());
+        return ApiResponse.of(SuccessStatus._SIGN_UP_OK,null);
+    }
+    @PostMapping("/reissue")
+    public ApiResponse<UserResponseDTO.JWTResponseDTO> reissue(HttpServletRequest request, HttpServletResponse response) {
+        //get refresh token
+        String refresh = userService.getRefresh(request, response, null);
+        String username = jwtUtil.getUsername(refresh);
+        String role = jwtUtil.getRole(refresh);
+
+        //make new JWT
+        String newAccess = jwtUtil.createJwt("access", username, role, 600000L);
+        String newRefresh = jwtUtil.createJwt("refresh", username, role, 86400000L);
+        //Refresh 토큰 저장 DB에 기존의 Refresh 토큰 삭제 후 새 Refresh 토큰 저장
+        refreshRepository.deleteByRefresh(refresh);
+        addRefreshEntity(username, newRefresh, 86400000L);
+        //response
+        response.setHeader("access", newAccess);
+        User user = userRepository.findByUsername(username);
+        user.setAccessToken(newAccess);
+        userRepository.save(user);
+        response.addCookie(createCookie("refresh", newRefresh));
+        UserResponseDTO.JWTResponseDTO result = UserConverter.toJwtResponseDTO(user,newRefresh, false);
+        return ApiResponse.of(SuccessStatus._REFRESH_OK, result);
+    }
+    private Cookie createCookie(String key, String value) {
+
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(24*60*60);
+        //cookie.setSecure(true);
+        //cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+    private void addRefreshEntity(String username, String refresh, Long expiredMs) {
+
+        Date date = new Date(System.currentTimeMillis() + expiredMs);
+
+        RefreshToken refreshEntity = new RefreshToken();
+        refreshEntity.setUsername(username);
+        refreshEntity.setRefresh(refresh);
+        refreshEntity.setExpiration(date.toString());
+
+        refreshRepository.save(refreshEntity);
+    }
+
+}

--- a/src/main/java/likelion/dotoread/web/dto/UserDto/GoogleResponse.java
+++ b/src/main/java/likelion/dotoread/web/dto/UserDto/GoogleResponse.java
@@ -1,0 +1,34 @@
+package likelion.dotoread.web.dto.UserDto;
+
+import java.util.Map;
+
+public class GoogleResponse{
+
+    private final Map<String, Object> attribute;
+
+    public GoogleResponse(Map<String, Object> attribute) {
+
+        this.attribute = attribute;
+    }
+
+    public String getProvider() {
+
+        return "google";
+    }
+
+    public String getProviderId() {
+
+        return attribute.get("sub").toString();
+    }
+
+    public String getEmail() {
+
+        return attribute.get("email").toString();
+    }
+
+
+    public String getName() {
+
+        return attribute.get("name").toString();
+    }
+}

--- a/src/main/java/likelion/dotoread/web/dto/UserDto/UserRequestDTO.java
+++ b/src/main/java/likelion/dotoread/web/dto/UserDto/UserRequestDTO.java
@@ -1,0 +1,10 @@
+package likelion.dotoread.web.dto.UserDto;
+
+import lombok.Getter;
+
+public class UserRequestDTO {
+    @Getter
+    public static class SignUpDTO {
+        private String nickname;
+    }
+}

--- a/src/main/java/likelion/dotoread/web/dto/UserDto/UserResponseDTO.java
+++ b/src/main/java/likelion/dotoread/web/dto/UserDto/UserResponseDTO.java
@@ -1,0 +1,21 @@
+package likelion.dotoread.web.dto.UserDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserResponseDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class JWTResponseDTO {
+        private Boolean isNew; //회원가입(true), 로그인(false)
+        private String accessToken;
+        private String refreshToken;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,3 +17,18 @@ spring:
         hbm2ddl:
           auto: update
         default_batch_fetch_size: 1000
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-name: google
+            client-id: ${CLIENT_ID}
+            client-secret: ${CLIENT_SECRET}
+            redirect-uri: http://localhost:8080/login/oauth2/code/google
+            authorization-grant-type: authorization_code
+            scope:
+              - profile
+              - email
+  jwt:
+    secret: ${JWT_SECRET}


### PR DESCRIPTION
## 📌 연관 이슈
- #5

## 💻 작업 내용

구글 소셜 로그인을 구현했습니다.

**[/login]**

해당 앤드포인트로 요청을 보낼 시, 구글 소셜 로그인이 진행됩니다. 로그인 진행 후에는 다음과 같은 응답을 받을 수 있습니다.

```jsx
{
  "isSuccess": true,
  "code": "OAUTH2001",
  "message": "구글 소셜 로그인이 완료되었습니다.",
  "result": {
    "isNew": true,
    "accessToken": "(실제 Access Token)",
    "refreshToken": "(실제 Refresh Token)"
  }
}
```

isNew는 현재 로그인한 User가 처음 로그인(=회원가입)하였는지, 재로그인인지 확인하는 용도입니다. isNew가 true이면 회원가입, false이면 재로그인입니다. 

응답을 통해 accessToken과 refreshToken을 확인할 수 있습니다. 또한 accessToken은 헤더에 “access”라는 이름으로, refreshToken은 쿠키에 “refresh”라는 이름으로 설정됩니다. 

**[/sign-up]**

로그인한 User의 닉네임을 설정할 수 있습니다. 해당 앤드포인트에 다음과 같은 POST 요청을 보내면 

```jsx
{
  "nickname": "닉네임"
}
```

다음과 같은 응답을 받을 수 있습니다.

```jsx
{
    "isSuccess": true,
    "code": "OAUTH2003",
    "message": "회원가입이 완료되었습니다."
}
```

**[/reissue]**

기본적으로 accessToken은 생성 후 1시간, refreshToken은 생성 후 14일 동안 유효합니다. refreshToken으로 만료된 accessToken과 refreshToken을 재발급 받을 수 있습니다.

해당 앤드포인트로 POST 요청을 보내면 다음과 같은 응답을 받을 수 있습니다.

```jsx
{
    "isSuccess": true,
    "code": "OAUTH2002",
    "message": "토큰 재발급이 완료되었습니다.",
    "result": {
        "isNew": false,
		    "accessToken": "(실제 Access Token)",
		    "refreshToken": "(실제 Refresh Token)"
    }
}
```

**[/logout]**

해당 앤드포인트로 POST 요청을 보낼 시 로그아웃을 진행할 수 있습니다. 로그아웃을 진행하면 DB에 저장된 refreshToken이 삭제됩니다. 응답은 다음과 같습니다. 

```jsx
{
    "isSuccess": true,
    "code": "OAUTH2004",
    "message": "로그아웃이 완료되었습니다."
}
```

**[추가적인 작업]**

- RefreshToken 엔티티를 생성했습니다. User들의 refreshToken을 저장합니다. 특정 유저의 refresh 정보는 username을 통해 찾을 수 있습니다. username은 이름이 아닌 유저를 식별하기 위한 값으로 사용됩니다.

- Bookmark에 visitCount 컬럼을 삭제하고 isVisited를 추가했습니다. default 값으로 false를 가집니다.

- CORS 에러 관련 설정을 해두었습니다.

### 📸 스크린샷 (선택)

### 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 기타 내용이 있다면 작성해주세요

- “/login”과 “/reissue”를 제외한 모든 앤드포인트는 인증을 필요로 합니다. 따라서 헤더에 accessToken을 설정 후, 요청을 보내야 합니다. 포스트맨에서 다음과 같이 헤더에 access, 쿠키에 refresh를 설정할 수 있습니다.

<img width="501" alt="image" src="https://github.com/user-attachments/assets/7d32b8a1-37f9-4a46-abba-eb7dd3e5b77c">
<img width="840" alt="image" src="https://github.com/user-attachments/assets/2b57a784-27a2-43df-81c2-a0661f7b6c3a">

- swagger로 테스트하려면 다음과 같이 accessToken을 Authorize에 넣으면 됩니다!
<img width="660" alt="image" src="https://github.com/user-attachments/assets/c6b6ac52-3dfe-4abe-85c2-641e1a0ac9e2">


- ”/reissue”의 경우에는 헤더에 accessToken, 그리고 반드시 쿠키에 refreshToken을 설정한 채 요청을 보내야 합니다.
- 헤더에 설정된 access Token을 기반으로 유저정보를 가져올 수 있습니다.
    
    ```java
    (예시)
        @GetMapping("/example")
        public ApiResponse example(HttpServletRequest http) {
            User user = userService.findUserByHttpServletRequest(http);
            ...
        }
    ```
    
    위와 같이 UserService의 findUserByHttpServletRequest 메서드를 이용하면 됩니다.